### PR TITLE
Implement PATCH /tests/:id endpoint

### DIFF
--- a/src/api/ApiError.ts
+++ b/src/api/ApiError.ts
@@ -12,6 +12,7 @@ export const apiErrorCodes = {
   ROLE_NOT_FOUND: 'role.not-found',
   PERMISSION_NOT_FOUND: 'permission.not-found',
   RESOURCE_NOT_FOUND: 'resource.not-found',
+  TEST_NOT_FOUND: 'test.not-found',
 
   TEST_TYPE_NAME_CONFLICT: 'test-type.name-already-exists',
 };

--- a/src/application/service/AddResultsToTest.ts
+++ b/src/application/service/AddResultsToTest.ts
@@ -1,0 +1,67 @@
+import { UserId } from '../../domain/model/user/UserId';
+import { Test } from '../../domain/model/test/Test';
+import { TestId } from '../../domain/model/test/TestId';
+import { TestTypeId } from '../../domain/model/testType/TestTypeId';
+import { TestRepository } from '../../domain/model/test/TestRepository';
+import { TestTypeRepository } from '../../domain/model/testType/TestTypeRepository';
+import { TestResultsCommand } from '../../api/interface';
+import { testResultsFactory } from './index';
+import { ResourceNotFoundError } from '../../domain/model/ResourceNotFoundError';
+import { TestType } from '../../domain/model/testType/TestType';
+import { User } from '../../domain/model/user/User';
+import { AccessDeniedError } from '../../domain/model/AccessDeniedError';
+import { DomainValidationError } from '../../domain/model/DomainValidationError';
+import { TestNotFoundError } from '../../domain/model/test/TestNotFoundError';
+import { AccessManagerFactory } from '../../domain/model/authentication/AccessManager';
+
+export class AddResultsToTest {
+  constructor(
+    private testRepository: TestRepository,
+    private testTypeRepository: TestTypeRepository,
+    private accessManagerFactory: AccessManagerFactory
+  ) {}
+
+  public async execute(actor: User, testId: string, resultsCommand: TestResultsCommand): Promise<Test> {
+    const test = await this.getTestOrFail(testId);
+    const testType = await this.getTestTypeOrFail(test.testTypeId);
+
+    await this.validateAccessAndPermissionToAddResults(actor, test, testType);
+
+    test.results = this.getResults(actor.id, testType, resultsCommand);
+    return this.testRepository.save(test);
+  }
+
+  private async getTestOrFail(testId: string) {
+    const test = await this.testRepository.findById(new TestId(testId));
+    if (!test) {
+      throw new TestNotFoundError(testId);
+    }
+    return test;
+  }
+
+  private async getTestTypeOrFail(testTypeId: TestTypeId) {
+    const testType = await this.testTypeRepository.findById(testTypeId);
+    if (!testType) {
+      throw new ResourceNotFoundError('testType', testTypeId.value);
+    }
+    return testType;
+  }
+
+  private async validateAccessAndPermissionToAddResults(actor: User, test: Test, testType: TestType) {
+    const hasAccess = await this.accessManagerFactory.forAuthenticatedUser(actor).canAccessUser(test.userId);
+    if (!hasAccess) {
+      throw new AccessDeniedError('ACCESS_PASS');
+    }
+    if (actor.permissions.indexOf(testType.neededPermissionToAddResults) === -1) {
+      throw new AccessDeniedError(testType.neededPermissionToAddResults);
+    }
+  }
+
+  private getResults(actorUserId: UserId, testType: TestType, results?: TestResultsCommand) {
+    if (!results || !results.details) {
+      throw new DomainValidationError('test.results', 'Results must not be undefined');
+    }
+
+    return testResultsFactory.create(actorUserId, testType, results.details);
+  }
+}

--- a/src/application/service/index.ts
+++ b/src/application/service/index.ts
@@ -39,6 +39,7 @@ import { AssignPermissionToRole } from './AssignPermissionToRole';
 import { GetRoles } from './GetRoles';
 import { GetPermissions } from './GetPermissions';
 import { CreateTestType } from './CreateTestType';
+import { AddResultsToTest } from './AddResultsToTest';
 
 let emailNotifier = new LoggingEmailNotifier();
 
@@ -91,12 +92,10 @@ export const exchangeAuthCode = new ExchangeAuthCode(
 );
 
 export const getTestTypes = new GetTestTypes(testTypeRepository);
-
-export const createSharingCode = new CreateSharingCode(sharingCodeRepository);
-
 export const createTest = new CreateTest(testRepository, testTypeRepository);
-
 export const getTests = new GetTests(testRepository);
 export const testResultsFactory = new ResultsFactory();
+export const addResultsToTest = new AddResultsToTest(testRepository, testTypeRepository, accessManagerFactory);
 
+export const createSharingCode = new CreateSharingCode(sharingCodeRepository);
 export const createAccessPass = new CreateAccessPass(accessPassRepository, sharingCodeRepository);

--- a/src/domain/model/authentication/AccessManager.ts
+++ b/src/domain/model/authentication/AccessManager.ts
@@ -1,12 +1,17 @@
 import { Authentication } from './Authentication';
 import { UserId } from '../user/UserId';
 import { AccessPassRepository } from '../accessPass/AccessPassRepository';
+import { User } from '../user/User';
 
 export class AccessManagerFactory {
   constructor(private accessPassRepository: AccessPassRepository) {}
 
   forAuthentication(authentication: Authentication) {
     return new AccessManager(this.accessPassRepository, authentication);
+  }
+
+  forAuthenticatedUser(user: User) {
+    return this.forAuthentication(new Authentication(user, user.roles, user.permissions));
   }
 }
 
@@ -20,11 +25,7 @@ export class AccessManager {
 
     const hasAccessPass = await this.hasAccessPassForUser(userId);
 
-    if (this.isLoggedInAsUser(userId) || hasAccessPass) {
-      return true;
-    }
-
-    return false;
+    return this.isLoggedInAsUser(userId) || hasAccessPass;
   }
 
   isLoggedInAsUser(userId: UserId): boolean {

--- a/src/domain/model/test/Test.ts
+++ b/src/domain/model/test/Test.ts
@@ -5,9 +5,9 @@ import { Results } from './Results';
 
 export class Test {
   constructor(
-    public id: TestId,
-    public userId: UserId,
-    public testTypeId: TestTypeId,
+    readonly id: TestId,
+    readonly userId: UserId,
+    readonly testTypeId: TestTypeId,
     public results?: Results,
     readonly creationTime: Date = new Date()
   ) {}

--- a/src/domain/model/test/TestNotFoundError.ts
+++ b/src/domain/model/test/TestNotFoundError.ts
@@ -1,0 +1,7 @@
+import { ResourceNotFoundError } from '../ResourceNotFoundError';
+
+export class TestNotFoundError extends ResourceNotFoundError {
+  constructor(readonly testId: string) {
+    super('test', testId);
+  }
+}


### PR DESCRIPTION
**When applied this will:**
Enable anyone can add results for an existing test as long as:
They have the necessary permission to add results for this type (neededPermissionToAddTestResults ) AND
They have an access pass to the test.userId or are logged in as the test.userId

