### PR TITLE
Interpretations persistence

### DIFF
--- a/src/api/routes/test.ts
+++ b/src/api/routes/test.ts
@@ -82,11 +82,7 @@ export default () => {
   return route.middleware();
 };
 
-export function mapTestToApiTest(test: Test | null) {
-  if (!test) {
-    return null;
-  }
-
+export function mapTestToApiTest(test: Test) {
   return {
     id: test.id.value,
     userId: test.userId.value,

--- a/src/application/service/tests/GetTests.ts
+++ b/src/application/service/tests/GetTests.ts
@@ -2,6 +2,7 @@ import { Test } from '../../../domain/model/test/Test';
 import { TestId } from '../../../domain/model/test/TestId';
 import { TestRepository } from '../../../domain/model/test/TestRepository';
 import { UserId } from '../../../domain/model/user/UserId';
+import { TestNotFoundError } from '../../../domain/model/test/TestNotFoundError';
 
 export class GetTests {
   constructor(private testRepository: TestRepository) {}
@@ -10,7 +11,11 @@ export class GetTests {
     return this.testRepository.findByUserId(new UserId(userId));
   }
 
-  async byId(id: string): Promise<Test | null> {
-    return this.testRepository.findById(new TestId(id));
+  async byId(id: string): Promise<Test> {
+    const test = await this.testRepository.findById(new TestId(id));
+    if (!test) {
+      throw new TestNotFoundError(id);
+    }
+    return test;
   }
 }

--- a/src/database/migrations/V3__addTestTypes.ts
+++ b/src/database/migrations/V3__addTestTypes.ts
@@ -6,6 +6,7 @@ export async function up(db: knex) {
     table.string('name').unique().notNullable();
     table.jsonb('results_schema').notNullable();
     table.string('needed_permission_to_add_results').notNullable().index();
+    table.jsonb('results_interpretation_rules').notNullable();
   });
 }
 

--- a/src/domain/Validators.ts
+++ b/src/domain/Validators.ts
@@ -33,8 +33,12 @@ export class Validators {
   }
 
   static validateJson(fieldName: string, doc: object, schema: object) {
-    if (!schema || !doc || !ajv.validate(schema, doc)) {
+    if (!this.isValidJson(doc, schema)) {
       throw new DomainValidationError(fieldName, 'The document does not follow the schema');
     }
+  }
+
+  static isValidJson(doc: object, schema: object): boolean {
+    return !!(schema && doc && ajv.validate(schema, doc));
   }
 }

--- a/src/domain/model/test/interpretation/Condition.test.ts
+++ b/src/domain/model/test/interpretation/Condition.test.ts
@@ -3,14 +3,14 @@ import { Condition } from './Condition';
 describe('Condition', () => {
   describe('SimpleCondition', () => {
     it('does not accept an invalid condition', () => {
-      expect(() => Condition.from({})).toThrow();
-      expect(() => Condition.from({ property: null, value: 3, comparator: '==' })).toThrow();
-      expect(() => Condition.from({ property: 'a', value: null, comparator: '' })).toThrow();
-      expect(() => Condition.from({ property: 'a', value: 3, comparator: '' })).toThrow();
+      expect(() => Condition.fromSchema({})).toThrow();
+      expect(() => Condition.fromSchema({ property: null, value: 3, comparator: '==' })).toThrow();
+      expect(() => Condition.fromSchema({ property: 'a', value: null, comparator: '' })).toThrow();
+      expect(() => Condition.fromSchema({ property: 'a', value: 3, comparator: '' })).toThrow();
     });
 
     it('correctly evaluates ">="', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '>=',
         value: 30,
@@ -22,7 +22,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates ">"', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '>',
         value: 30,
@@ -34,7 +34,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "<="', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '<=',
         value: 30,
@@ -46,7 +46,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "<"', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '<',
         value: 30,
@@ -58,7 +58,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "==" for numbers', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '==',
         value: 30,
@@ -69,7 +69,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "==" for strings', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '==',
         value: 'value',
@@ -80,7 +80,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "==" for booleans', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '==',
         value: false,
@@ -91,7 +91,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "!=" for numbers', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '!=',
         value: 30,
@@ -102,7 +102,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "!=" for strings', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '!=',
         value: 'value',
@@ -113,7 +113,7 @@ describe('Condition', () => {
     });
 
     it('correctly evaluates "!=" for booleans', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         property: 'c',
         comparator: '!=',
         value: false,
@@ -126,11 +126,11 @@ describe('Condition', () => {
 
   describe('AndCondition', () => {
     it('throws an error for an invalid AND condition', () => {
-      expect(() => Condition.from({ and: {} })).toThrow();
+      expect(() => Condition.fromSchema({ and: {} })).toThrow();
     });
 
     it('correctly calculates conjugation', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         and: [
           {
             property: 'c',
@@ -154,11 +154,11 @@ describe('Condition', () => {
 
   describe('OrCondition', () => {
     it('throws an error for an invalid OR condition', () => {
-      expect(() => Condition.from({ or: {} })).toThrow();
+      expect(() => Condition.fromSchema({ or: {} })).toThrow();
     });
 
     it('correctly calculates disjunction', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         or: [
           {
             property: 'c',
@@ -182,7 +182,7 @@ describe('Condition', () => {
 
   describe('Nested Conditions', () => {
     it('correctly calculates complex nested expressions', () => {
-      const condition = Condition.from({
+      const condition = Condition.fromSchema({
         or: [
           {
             property: 'c',

--- a/src/domain/model/test/interpretation/Condition.ts
+++ b/src/domain/model/test/interpretation/Condition.ts
@@ -1,133 +1,19 @@
 import { Validators } from '../../../Validators';
-import { DomainValidationError } from '../../DomainValidationError';
 
-export interface Condition {
-  evaluate(obj: any): boolean;
-  toSchema(): object;
-}
-
-export namespace Condition {
-  export function fromSchema(conditionSchema: any): Condition {
-    if (conditionSchema.and) {
-      return AndCondition.fromSchema(conditionSchema.and);
-    }
-    if (conditionSchema.or) {
-      return OrCondition.fromSchema(conditionSchema.or);
-    }
-    if (conditionSchema.comparator) {
-      return SimpleCondition.fromSchema(conditionSchema);
-    }
-    throw new DomainValidationError('conditionSchema', `${JSON.stringify(conditionSchema)} is not a valid condition`);
-  }
-}
-
-class OrCondition implements Condition {
-  constructor(private conditions: Condition[]) {}
-
-  evaluate(obj: object): boolean {
-    for (const condition of this.conditions) {
-      if (condition.evaluate(obj)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  toSchema(): object {
-    return {
-      and: this.conditions.map((condition) => condition.toSchema()),
-    };
-  }
-
-  static fromSchema(conditionSchema: any) {
-    if (!Array.isArray(conditionSchema)) {
-      throw new DomainValidationError(
-        'conditionSchema',
-        `${JSON.stringify(conditionSchema)} is not a valid OR condition`
-      );
-    }
-    return new OrCondition(conditionSchema.map(Condition.fromSchema));
-  }
-}
-
-class AndCondition implements Condition {
-  constructor(private conditions: Condition[]) {}
-
-  evaluate(obj: any): boolean {
-    for (const condition of this.conditions) {
-      if (!condition.evaluate(obj)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  toSchema(): object {
-    return {
-      and: this.conditions.map((condition) => condition.toSchema()),
-    };
-  }
-
-  static fromSchema(conditionSchema: any) {
-    if (!Array.isArray(conditionSchema)) {
-      throw new DomainValidationError(
-        'conditionSchema',
-        `${JSON.stringify(conditionSchema)} is not a valid AND condition`
-      );
-    }
-    return new AndCondition(conditionSchema.map(Condition.fromSchema));
-  }
-}
-
-class SimpleCondition implements Condition {
-  constructor(
-    private property: string,
-    private comparator: '==' | '!=' | '>' | '<' | '<=' | '>=',
-    private value: string | boolean | number
-  ) {
-    Validators.validateNotEmpty('simpleCondition.property', property);
-    Validators.validateNotEmpty('simpleCondition.comparator', comparator);
-    Validators.validateNotNullOrUndefined('simpleCondition.property', value);
+export class Condition {
+  constructor(private schema: object) {
+    Validators.validateSchema('schema', schema);
   }
 
   evaluate(obj: any): boolean {
-    switch (this.comparator) {
-      case '==':
-        return obj[this.property] === this.value;
-      case '!=':
-        return obj[this.property] !== this.value;
-      case '>=':
-        return obj[this.property] >= this.value;
-      case '<=':
-        return obj[this.property] <= this.value;
-      case '<':
-        return obj[this.property] < this.value;
-      case '>':
-        return obj[this.property] > this.value;
-      default:
-        throw new DomainValidationError(
-          'simpleCondition.comparator',
-          `${this.comparator} is not an accepted comparator`
-        );
-    }
+    return Validators.isValidJson(obj, this.schema);
   }
 
   toSchema(): object {
-    return {
-      property: this.property,
-      comparator: this.comparator,
-      value: this.value,
-    };
+    return this.schema;
   }
 
-  static fromSchema(conditionSchema: any) {
-    try {
-      return new SimpleCondition(conditionSchema.property, conditionSchema.comparator, conditionSchema.value);
-    } catch (error) {
-      throw new DomainValidationError(
-        'conditionSchema',
-        `${JSON.stringify(conditionSchema)} is not a valid SimpleCondition`
-      );
-    }
+  static fromSchema(jsonSchema: object) {
+    return new Condition(jsonSchema);
   }
 }

--- a/src/domain/model/test/interpretation/InterpretationRules.test.ts
+++ b/src/domain/model/test/interpretation/InterpretationRules.test.ts
@@ -6,11 +6,11 @@ import { ConfidenceLevel } from '../ConfidenceLevel';
 
 describe('InterpretationRules', () => {
   it('does not allow creating an invalid interpretation', () => {
-    expect(() => InterpretationRules.from([{}])).toThrow();
+    expect(() => InterpretationRules.fromSchema([{}])).toThrow();
   });
 
   it('produces a correct Interpretation when the condition evaluates to true', () => {
-    const interpretationRule = InterpretationRules.from([
+    const interpretationRule = InterpretationRules.fromSchema([
       {
         output: {
           namePattern: 'Some pattern {{value}}',
@@ -36,7 +36,7 @@ describe('InterpretationRules', () => {
   });
 
   it('produces no interpretation when the condition evaluates to false', () => {
-    const interpretationRule = InterpretationRules.from([
+    const interpretationRule = InterpretationRules.fromSchema([
       {
         output: {
           namePattern: 'Some pattern {{value}}',
@@ -60,7 +60,7 @@ describe('InterpretationRules', () => {
   });
 
   it('produces no interpretations for an empty interpretation rule array', () => {
-    const interpretationRule = InterpretationRules.from([]);
+    const interpretationRule = InterpretationRules.fromSchema([]);
 
     const results = new Results(new UserId(), { c: 1 }, ConfidenceLevel.LOW);
     const interpretations = interpretationRule.interpret(results);
@@ -69,7 +69,7 @@ describe('InterpretationRules', () => {
   });
 
   it('produces multiple interpretations if multiple rules match', () => {
-    const interpretationRule = InterpretationRules.from([
+    const interpretationRule = InterpretationRules.fromSchema([
       {
         output: {
           namePattern: 'Some pattern {{value}}',

--- a/src/domain/model/test/interpretation/InterpretationRules.test.ts
+++ b/src/domain/model/test/interpretation/InterpretationRules.test.ts
@@ -20,9 +20,11 @@ describe('InterpretationRules', () => {
           },
         },
         condition: {
-          property: 'c',
-          comparator: '>',
-          value: 2,
+          type: 'object',
+          properties: {
+            c: { type: 'number', not: { maximum: 2 } },
+          },
+          required: ['c'],
         },
       },
     ]);
@@ -46,9 +48,11 @@ describe('InterpretationRules', () => {
           },
         },
         condition: {
-          property: 'c',
-          comparator: '>',
-          value: 2,
+          type: 'object',
+          properties: {
+            c: { type: 'number', not: { maximum: 2 } },
+          },
+          required: ['c'],
         },
       },
     ]);
@@ -79,9 +83,11 @@ describe('InterpretationRules', () => {
           },
         },
         condition: {
-          property: 'c',
-          comparator: '>',
-          value: 2,
+          type: 'object',
+          properties: {
+            c: { type: 'number', not: { maximum: 2 } },
+          },
+          required: ['c'],
         },
       },
       {
@@ -93,9 +99,11 @@ describe('InterpretationRules', () => {
           },
         },
         condition: {
-          property: 'c',
-          comparator: '>',
-          value: 1,
+          type: 'object',
+          properties: {
+            c: { type: 'number', not: { maximum: 1 } },
+          },
+          required: ['c'],
         },
       },
     ]);

--- a/src/domain/model/test/interpretation/InterpretationRules.ts
+++ b/src/domain/model/test/interpretation/InterpretationRules.ts
@@ -6,17 +6,21 @@ import { DomainValidationError } from '../../DomainValidationError';
 import { Validators } from '../../../Validators';
 
 export class InterpretationRules {
-  constructor(private rules: InterpretationRule[]) {}
+  constructor(readonly rules: InterpretationRule[]) {}
 
   interpret(results: Results): Array<Interpretation> {
     return this.rules.filter((rule) => rule.matches(results)).map((rule) => rule.interpret(results));
   }
 
-  static from(interpretationRulesSchema: Array<any>) {
+  toSchema() {
+    return this.rules.map((rule) => rule.toSchema());
+  }
+
+  static fromSchema(interpretationRulesSchema: Array<any>) {
     if (!Array.isArray(interpretationRulesSchema)) {
       throw new DomainValidationError('interpretationRules', 'InterpretationRules must be an array');
     }
-    return new InterpretationRules(interpretationRulesSchema.map(InterpretationRule.from));
+    return new InterpretationRules(interpretationRulesSchema.map(InterpretationRule.fromSchema));
   }
 }
 
@@ -31,13 +35,20 @@ class InterpretationRule {
     return this.condition.evaluate(results.details);
   }
 
-  static from(interpretationRuleSchema: any) {
+  toSchema() {
+    return {
+      output: this.output.toSchema(),
+      condition: this.condition.toSchema(),
+    };
+  }
+
+  static fromSchema(interpretationRuleSchema: any) {
     Validators.validateNotNullOrUndefined('interpretationRule.output', interpretationRuleSchema.output);
     Validators.validateNotNullOrUndefined('interpretationRule.condition', interpretationRuleSchema.condition);
 
     return new InterpretationRule(
       OutputPattern.from(interpretationRuleSchema.output),
-      Condition.from(interpretationRuleSchema.condition)
+      Condition.fromSchema(interpretationRuleSchema.condition)
     );
   }
 }

--- a/src/domain/model/test/interpretation/Output.ts
+++ b/src/domain/model/test/interpretation/Output.ts
@@ -24,6 +24,14 @@ export class OutputPattern {
     return variables;
   }
 
+  toSchema() {
+    return {
+      namePattern: this.namePattern,
+      theme: this.theme,
+      propertyVariables: this.propertyVariables,
+    };
+  }
+
   static from(outputSchema: any) {
     return new OutputPattern(outputSchema.namePattern, outputSchema.theme, outputSchema.propertyVariables);
   }

--- a/src/domain/model/testType/TestType.ts
+++ b/src/domain/model/testType/TestType.ts
@@ -1,16 +1,18 @@
-import { DomainValidationError } from '../DomainValidationError';
 import { TestTypeId } from './TestTypeId';
 import { Validators } from '../../Validators';
+import { InterpretationRules } from '../test/interpretation/InterpretationRules';
 
 export class TestType {
   constructor(
     readonly id: TestTypeId,
     readonly name: string,
     readonly resultsSchema: object,
-    readonly neededPermissionToAddResults: string
+    readonly neededPermissionToAddResults: string,
+    readonly interpretationRules: InterpretationRules = InterpretationRules.fromSchema([])
   ) {
     Validators.validateNotEmpty('name', name);
     Validators.validateNotEmpty('neededPermissionToAddResults', neededPermissionToAddResults);
+    Validators.validateNotNullOrUndefined('interpretationRules', interpretationRules);
     Validators.validateSchema('resultsSchema', resultsSchema);
   }
 }

--- a/src/infrastructure/persistence/PsqlTestTypeRepository.test.ts
+++ b/src/infrastructure/persistence/PsqlTestTypeRepository.test.ts
@@ -3,8 +3,10 @@ import { PsqlTestTypeRepository } from './PsqlTestTypeRepository';
 import { TestTypeId } from '../../domain/model/testType/TestTypeId';
 import { TestType } from '../../domain/model/testType/TestType';
 import { cleanupDatabase } from '../../test/cleanupDatabase';
-import { aTestType } from '../../test/domainFactories';
+import { antibodyTestTypeInterpretationRules, aTestType } from '../../test/domainFactories';
 import { TestTypeNameAlreadyExists } from '../../domain/model/testType/TestTypeRepository';
+import { InterpretationRules } from '../../domain/model/test/interpretation/InterpretationRules';
+import { InterpretationTheme } from '../../domain/model/test/interpretation/Interpretation';
 
 describe('PsqlTestTypeRepository', () => {
   const psqlTestTypeRepository = new PsqlTestTypeRepository(database);
@@ -65,8 +67,19 @@ describe('PsqlTestTypeRepository', () => {
 
     expect(persistedTestType).toEqual(testType);
   });
-});
 
+  it('inserts new and retrieves a test type containing interpretation rules', async () => {
+    const interpretationRules = antibodyTestTypeInterpretationRules();
+
+    const testType = await psqlTestTypeRepository.save(
+      new TestType(new TestTypeId(), 'PCR', {}, 'PCR_PERMISSION', interpretationRules)
+    );
+
+    const persistedTestType = await psqlTestTypeRepository.findById(testType.id);
+
+    expect(persistedTestType).toEqual(testType);
+  });
+});
 afterAll(() => {
   return database.destroy();
 });

--- a/src/test/domainFactories.ts
+++ b/src/test/domainFactories.ts
@@ -97,18 +97,12 @@ export function antibodyTestTypeInterpretationRules() {
         variables: {},
       },
       condition: {
-        and: [
-          {
-            property: 'c',
-            comparator: '==',
-            value: true,
-          },
-          {
-            property: 'igg',
-            comparator: '==',
-            value: true,
-          },
-        ],
+        type: 'object',
+        properties: {
+          c: { type: 'boolean', const: true },
+          igg: { type: 'boolean', const: true },
+        },
+        required: ['c', 'igg'],
       },
     },
     {
@@ -117,18 +111,12 @@ export function antibodyTestTypeInterpretationRules() {
         theme: InterpretationTheme.NEUTRAL,
       },
       condition: {
-        and: [
-          {
-            property: 'c',
-            comparator: '==',
-            value: true,
-          },
-          {
-            property: 'igm',
-            comparator: '==',
-            value: true,
-          },
-        ],
+        type: 'object',
+        properties: {
+          c: { type: 'boolean', const: true },
+          igm: { type: 'boolean', const: true },
+        },
+        required: ['c', 'igm'],
       },
     },
     {
@@ -137,9 +125,11 @@ export function antibodyTestTypeInterpretationRules() {
         theme: InterpretationTheme.MUTED,
       },
       condition: {
-        property: 'c',
-        comparator: '==',
-        value: false,
+        type: 'object',
+        properties: {
+          c: { type: 'boolean', const: false },
+        },
+        required: ['c'],
       },
     },
   ]);

--- a/src/test/domainFactories.ts
+++ b/src/test/domainFactories.ts
@@ -15,6 +15,8 @@ import { Test } from '../domain/model/test/Test';
 import { TestId } from '../domain/model/test/TestId';
 import { Results } from '../domain/model/test/Results';
 import { ConfidenceLevel } from '../domain/model/test/ConfidenceLevel';
+import { InterpretationRules } from '../domain/model/test/interpretation/InterpretationRules';
+import { InterpretationTheme } from '../domain/model/test/interpretation/Interpretation';
 
 export function aNewUser() {
   return new User(new UserId(), anEmail());
@@ -84,4 +86,61 @@ export function aTest(
 
 export function aResult(userId = new UserId(), details = { c: true, igg: true, igm: true }, notes = 'results notes') {
   return new Results(userId, details, ConfidenceLevel.LOW, notes);
+}
+
+export function antibodyTestTypeInterpretationRules() {
+  return InterpretationRules.fromSchema([
+    {
+      output: {
+        namePattern: 'IgG antibodies found',
+        theme: InterpretationTheme.POSITIVE,
+        variables: {},
+      },
+      condition: {
+        and: [
+          {
+            property: 'c',
+            comparator: '==',
+            value: true,
+          },
+          {
+            property: 'igg',
+            comparator: '==',
+            value: true,
+          },
+        ],
+      },
+    },
+    {
+      output: {
+        namePattern: 'IgM antibodies not found',
+        theme: InterpretationTheme.NEUTRAL,
+      },
+      condition: {
+        and: [
+          {
+            property: 'c',
+            comparator: '==',
+            value: true,
+          },
+          {
+            property: 'igm',
+            comparator: '==',
+            value: true,
+          },
+        ],
+      },
+    },
+    {
+      output: {
+        namePattern: 'Test Invalid',
+        theme: InterpretationTheme.MUTED,
+      },
+      condition: {
+        property: 'c',
+        comparator: '==',
+        value: false,
+      },
+    },
+  ]);
 }


### PR DESCRIPTION
**When applied this will**
Start persisting interpretation rules in test type. 
No work is done yet on the API to accept rules during creation or return them on the GET apis (this will come in a separate PR)