### PR TITLE
Setup mode

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -13,3 +13,6 @@ port: PORT
 
 rollbar:
   token: ROLLBAR_TOKEN
+
+app:
+  setupModeEnabled: APP_SETUP_MODE_ENABLED

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -23,4 +23,7 @@ jwt:
   timeToLiveInHours: 336
   secret: 1-9182fj1wofj1-08fj182fj1-90fj21-0r89j12-8rh
 
+app:
+  setupModeEnabled: false
+
 port: 1337

--- a/src/application/service/index.ts
+++ b/src/application/service/index.ts
@@ -91,7 +91,11 @@ export const getUser = new GetUser(userRepository);
 
 export const updateUser = new UpdateUser(userRepository);
 
-export const getExistingOrCreateNewUser = new GetExistingOrCreateNewUser(userRepository, roleRepository);
+export const getExistingOrCreateNewUser = new GetExistingOrCreateNewUser(
+  userRepository,
+  roleRepository,
+  config.get('app.setupModeEnabled')
+);
 
 export const bulkCreateUsers = new BulkCreateUsers(userRepository, roleRepository);
 

--- a/src/application/service/users/GetExistingOrCreateNewUser.test.ts
+++ b/src/application/service/users/GetExistingOrCreateNewUser.test.ts
@@ -3,10 +3,10 @@ import database from '../../../database';
 import { GetExistingOrCreateNewUser } from './GetExistingOrCreateNewUser';
 import { cleanupDatabase } from '../../../test/cleanupDatabase';
 import { anEmail, aNewUser } from '../../../test/domainFactories';
-import { USER } from '../../../domain/model/authentication/Roles';
+import { ADMIN, USER } from '../../../domain/model/authentication/Roles';
 
 describe('GetExistingOrCreateNewUser', () => {
-  const getExistingOrCreateNewUser = new GetExistingOrCreateNewUser(userRepository, roleRepository);
+  const getExistingOrCreateNewUser = new GetExistingOrCreateNewUser(userRepository, roleRepository, true);
 
   beforeEach(async () => {
     await cleanupDatabase();
@@ -26,8 +26,33 @@ describe('GetExistingOrCreateNewUser', () => {
     const resultUser = await getExistingOrCreateNewUser.execute(email.value);
 
     expect(resultUser).toBeDefined();
-    expect(resultUser.roles).toEqual([USER]);
     expect(resultUser.email).toEqual(email);
+  });
+
+  describe('when setup mode is enabled', () => {
+    const getExistingOrCreateNewUser = new GetExistingOrCreateNewUser(userRepository, roleRepository, true);
+
+    it('creates new users with the USER and the ADMIN role', async () => {
+      const email = anEmail();
+
+      const resultUser = await getExistingOrCreateNewUser.execute(email.value);
+
+      expect(resultUser.roles).toContain(USER);
+      expect(resultUser.roles).toContain(ADMIN);
+    });
+  });
+
+  describe('when setup mode is disabled', () => {
+    const getExistingOrCreateNewUser = new GetExistingOrCreateNewUser(userRepository, roleRepository, false);
+
+    it('creates new users with only the USER role', async () => {
+      const email = anEmail();
+
+      const resultUser = await getExistingOrCreateNewUser.execute(email.value);
+
+      expect(resultUser.roles).toContain(USER);
+      expect(resultUser.roles).not.toContain(ADMIN);
+    });
   });
 });
 

--- a/src/infrastructure/persistence/PsqlPermissionRepository.ts
+++ b/src/infrastructure/persistence/PsqlPermissionRepository.ts
@@ -25,6 +25,7 @@ export class PsqlPermissionRepository implements PermissionRepository {
         `
       insert into permission (name, creation_time)
       values (:name, :creation_time)
+      on conflict do nothing
     `,
         {
           name: permission.name,

--- a/src/presentation/Application.ts
+++ b/src/presentation/Application.ts
@@ -1,13 +1,8 @@
 import { migrateLatest, rollbackDatabase } from '../database';
-import { createSeedDataForTestingPeriod } from '../database/testSeed';
 import { RootController } from './api/RootController';
 import logger from '../infrastructure/logging/logger';
 
 export class Application {
-  public getExpressApp() {
-    return;
-  }
-
   public async createAndRun() {
     await this.migrateDatabase();
     logger.info('DB connected and migrated');

--- a/src/presentation/Application.ts
+++ b/src/presentation/Application.ts
@@ -21,9 +21,6 @@ export class Application {
       await rollbackDatabase();
 
       await migrateLatest();
-
-      //TODO: Remove before rolling out to production
-      await createSeedDataForTestingPeriod();
     } catch (error) {
       logger.error('Failed to apply migrations', error);
       process.exit(1);

--- a/src/presentation/Application.ts
+++ b/src/presentation/Application.ts
@@ -1,4 +1,4 @@
-import { migrateLatest, rollbackDatabase } from '../database';
+import { migrateLatest } from '../database';
 import { RootController } from './api/RootController';
 import logger from '../infrastructure/logging/logger';
 
@@ -12,9 +12,6 @@ export class Application {
 
   private async migrateDatabase() {
     try {
-      //TODO: Remove before rolling out to production
-      await rollbackDatabase();
-
       await migrateLatest();
     } catch (error) {
       logger.error('Failed to apply migrations', error);

--- a/src/test/persistedEntities.ts
+++ b/src/test/persistedEntities.ts
@@ -1,11 +1,10 @@
 import { aNewUser, aRoleWithPermissions } from './domainFactories';
-import { ADMIN } from '../domain/model/authentication/Roles';
 import { Permission } from '../domain/model/authentication/Permission';
 import { permissionRepository, roleRepository, userRepository } from '../infrastructure/persistence';
 
 export async function persistedUserWithRoleAndPermissions(roleName: string, permissionNames: string[]) {
   const role = aRoleWithPermissions(
-    ADMIN,
+    roleName,
     permissionNames.map((permissionName) => new Permission(permissionName))
   );
   const admin = aNewUser();


### PR DESCRIPTION
**When applied this will**
1. Create an `APP_SETUP_MODE_ENABLED` configuration parameter. When it is set to `true`, every new user  that registers is being assigned the role `ADMIN` in addition to the role `USER`. This can be used during the first runs of the app and then it should be disabled. (default: false)

2. Insert the roles for ADMIN, USER and all the currently known permissions

3. Stop rolling back the database on every run and disable applying seed data. 
 