### PR TITLE
Capital case names when imported from dokobit

### DIFF
--- a/src/infrastructure/idAuthentication/DokobitAuthenticationProvider.test.ts
+++ b/src/infrastructure/idAuthentication/DokobitAuthenticationProvider.test.ts
@@ -49,8 +49,8 @@ describe('Dokobit authentication provider', () => {
         if (sessionToken === 'seshToken') {
           return {
             code: '39210030814',
-            name: 'Indrek',
-            surname: 'Nolan',
+            name: 'INDREK TEST',
+            surname: "o'nolan",
             countryCode: 'ee',
           };
         }
@@ -60,8 +60,8 @@ describe('Dokobit authentication provider', () => {
     const response = await provider.authenticate(new AuthenticationSessionToken('seshToken'));
 
     expect(response.code).toBe('39210030814');
-    expect(response.profile.firstName).toBe('Indrek');
-    expect(response.profile.lastName).toBe('Nolan');
+    expect(response.profile.firstName).toBe('Indrek Test');
+    expect(response.profile.lastName).toBe("O'Nolan");
     expect(response.profile.dateOfBirth.toString()).toEqual(new DateOfBirth(1992, 10, 3).toString());
     expect(response.profile.sex).toEqual(Sex.MALE);
   });

--- a/src/infrastructure/idAuthentication/DokobitAuthenticationProvider.ts
+++ b/src/infrastructure/idAuthentication/DokobitAuthenticationProvider.ts
@@ -55,8 +55,20 @@ export class DokobitAuthenticationProvider implements AuthenticationProvider {
 }
 
 function mapToProfile(sessionStatus: DokobitSessionStatus): Profile {
-  var id = getAndValidateEstonianIdCode(sessionStatus);
-  return new Profile(sessionStatus.name, sessionStatus.surname, DateOfBirth.fromDate(id.getBirthday()), getSex(id));
+  const id = getAndValidateEstonianIdCode(sessionStatus);
+  return new Profile(
+    capitalizeName(sessionStatus.name),
+    capitalizeName(sessionStatus.surname),
+    DateOfBirth.fromDate(id.getBirthday()),
+    getSex(id)
+  );
+}
+
+function capitalizeName(name: string) {
+  if (!name) {
+    return name;
+  }
+  return name.replace(/\b(\w)/g, (s) => s.toUpperCase());
 }
 
 function getAndValidateEstonianIdCode(sessionStatus: DokobitSessionStatus): Isikukood {

--- a/src/infrastructure/idAuthentication/DokobitAuthenticationProvider.ts
+++ b/src/infrastructure/idAuthentication/DokobitAuthenticationProvider.ts
@@ -68,7 +68,7 @@ function capitalizeName(name: string) {
   if (!name) {
     return name;
   }
-  return name.replace(/\b(\w)/g, (s) => s.toUpperCase());
+  return name.toLowerCase().replace(/\b(\w)/g, (s) => s.toUpperCase());
 }
 
 function getAndValidateEstonianIdCode(sessionStatus: DokobitSessionStatus): Isikukood {


### PR DESCRIPTION
No longer imports all caps names, but instead uses regex word boundaries to capitalize those names.