### PR TITLE
Make test notes larger

### DIFF
--- a/src/database/migrations/V9__makeTestNotesLarger.ts
+++ b/src/database/migrations/V9__makeTestNotesLarger.ts
@@ -1,0 +1,13 @@
+import knex from 'knex';
+
+export async function up(db: knex) {
+  await db.schema.alterTable('test_results', (table) => {
+    table.string('notes', 3000).notNullable().alter();
+  });
+}
+
+export async function down(db: knex) {
+  await db.schema.alterTable('test_results', (table) => {
+    table.string('notes').notNullable().alter();
+  });
+}


### PR DESCRIPTION
Chose a new arbitrary limit of 3000 instead of the 255 default.